### PR TITLE
update docker-compose

### DIFF
--- a/client/src/helper.js
+++ b/client/src/helper.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-const BASE_URL = "http://localhost:5000/api/";
+const BASE_URL = "/api/";
 const TOKEN =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzMTFkOTZlMTczNjhjYjc3YmM5NzBlMiIsImlzQWRtaW4iOnRydWUsImlhdCI6MTY2MjYzMTc2MiwiZXhwIjoxNjYyODkwOTYyfQ.LXy0qhPMzUt9_7iFf2nxPmXkNFTBHMX07t9_jlY1pTs";
 export const publicRequest = axios.create({

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    listen [::]:80;
+    location / {
+        proxy_pass http://ecom-shop-client;
+    }    
+    location /api {
+        proxy_pass http://ecom-shop-api:5000;
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,21 +1,8 @@
 version: '3.8'
 services:
-  mongo:
-    image: mongo
-    restart: unless-stopped
-    environment:
-      - PUID=1000
-      - PGID=1000
-    ports: 
-      - 27017:27017
-    volumes:
-      - mongodb:/data/db
-    networks:
-      - mongodb_network
-  
   ecom-shop-api:
     environment:
-      - MONGO=mongodb://mongo:27017
+      - MONGO=mongodb+srv://edwardduong:anhden11@ecom-shop.pqzstr4.mongodb.net/?retryWrites=true&w=majority
     build:
       context: .
       dockerfile: express.Dockerfile
@@ -25,24 +12,33 @@ services:
     ports:
       - 5000:5000
     command: node index.js
-    depends_on:
-      - mongo
     networks:
-      - mongodb_network
-
+      - ecom_network
   client:
     build: 
       context: .
       dockerfile: client.prod.Dockerfile
     container_name: ecom-shop-client
-    ports:
-      - 80:80
+    # ports:
+    #   - 80:80
     depends_on:
       - ecom-shop-api
-
-volumes:
-  mongodb:
+    networks:
+      - ecom_network
+  
+  proxy:
+    build:
+      context: .
+      dockerfile: proxy.Dockerfile
+    container_name: proxy
+    ports: 
+      - 80:80
+    depends_on:
+      - client
+      - ecom-shop-api
+    networks:
+      - ecom_network
 
 networks:
-  mongodb_network:
-    name: mongodb_network
+  ecom_network:
+    name: ecom_network

--- a/proxy.Dockerfile
+++ b/proxy.Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx:stable-alpine
+
+WORKDIR /usr/share/nginx/html
+
+COPY default.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["/bin/sh", "-c", "exec nginx -g 'daemon off;';"]


### PR DESCRIPTION
- Create and update docker-compose prod to have third container `proxy`
- Update the baseURL in client so that it fetch API correctly from node express API
- Create a `default.conf` to configure proxy
- Deleting the old code: mongodb container is unneeded